### PR TITLE
[CoreData] CalendarView 에서 CoreData에 저장된 값을 기반으로 그리는 로직

### DIFF
--- a/Notifisor/Notifisor.xcodeproj/project.pbxproj
+++ b/Notifisor/Notifisor.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		00106531290176FB00100B88 /* Day + extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00106530290176FB00100B88 /* Day + extension.swift */; };
 		0032950528F7EC53002376DD /* RepeatSectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0032950428F7EC53002376DD /* RepeatSectionCell.swift */; };
 		0032950728F7EE24002376DD /* RepeatSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0032950628F7EE24002376DD /* RepeatSectionView.swift */; };
 		0032950928F83573002376DD /* FulfillmentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0032950828F83573002376DD /* FulfillmentView.swift */; };
@@ -43,6 +44,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		00106530290176FB00100B88 /* Day + extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Day + extension.swift"; sourceTree = "<group>"; };
 		0032950428F7EC53002376DD /* RepeatSectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepeatSectionCell.swift; sourceTree = "<group>"; };
 		0032950628F7EE24002376DD /* RepeatSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepeatSectionView.swift; sourceTree = "<group>"; };
 		0032950828F83573002376DD /* FulfillmentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FulfillmentView.swift; sourceTree = "<group>"; };
@@ -245,6 +247,7 @@
 				6CE5774828F8010C00A4CF7A /* Date + extension.swift */,
 				6CE5775028F94E6300A4CF7A /* Calendar + extension.swift */,
 				00FF9FF828FFFFFB0079825A /* Month + extension.swift */,
+				00106530290176FB00100B88 /* Day + extension.swift */,
 				6CE5775228F94EC900A4CF7A /* DateFormatter + extension.swift */,
 			);
 			path = Extension;
@@ -342,6 +345,7 @@
 				6CE5774128F7E8A400A4CF7A /* Unit.swift in Sources */,
 				00FF9FF928FFFFFB0079825A /* Month + extension.swift in Sources */,
 				0032952528F9024C002376DD /* MenuView.swift in Sources */,
+				00106531290176FB00100B88 /* Day + extension.swift in Sources */,
 				6CA163DF28F7A89F00E018F4 /* DailyNoticeCell.swift in Sources */,
 				6CE5774D28F8376200A4CF7A /* CalendarView.swift in Sources */,
 				6CA163E528F7A8E100E018F4 /* Notice.swift in Sources */,

--- a/Notifisor/Notifisor.xcodeproj/project.pbxproj
+++ b/Notifisor/Notifisor.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		00D9DB4428FD2B060030A2C7 /* DayOfWeekView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00D9DB4328FD2B060030A2C7 /* DayOfWeekView.swift */; };
 		00DAAD3C290002C300BCE729 /* Month+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00DAAD3A290002C300BCE729 /* Month+CoreDataClass.swift */; };
 		00DAAD3D290002C300BCE729 /* Month+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00DAAD3B290002C300BCE729 /* Month+CoreDataProperties.swift */; };
+		00E08A9A2901134B0008D743 /* Day+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E08A982901134B0008D743 /* Day+CoreDataClass.swift */; };
+		00E08A9B2901134B0008D743 /* Day+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E08A992901134B0008D743 /* Day+CoreDataProperties.swift */; };
 		00FF9FF928FFFFFB0079825A /* Month + extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00FF9FF828FFFFFB0079825A /* Month + extension.swift */; };
 		6C316A2028F6956D006A7473 /* NotifisorApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C316A1F28F6956D006A7473 /* NotifisorApp.swift */; };
 		6C316A2228F6956D006A7473 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C316A2128F6956D006A7473 /* ContentView.swift */; };
@@ -53,6 +55,8 @@
 		00D9DB4328FD2B060030A2C7 /* DayOfWeekView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayOfWeekView.swift; sourceTree = "<group>"; };
 		00DAAD3A290002C300BCE729 /* Month+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "Month+CoreDataClass.swift"; path = "Notifisor/CoreData/Month+CoreDataClass.swift"; sourceTree = "<group>"; };
 		00DAAD3B290002C300BCE729 /* Month+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "Month+CoreDataProperties.swift"; path = "Notifisor/CoreData/Month+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		00E08A982901134B0008D743 /* Day+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "Day+CoreDataClass.swift"; path = "Notifisor/CoreData/Day+CoreDataClass.swift"; sourceTree = "<group>"; };
+		00E08A992901134B0008D743 /* Day+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "Day+CoreDataProperties.swift"; path = "Notifisor/CoreData/Day+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		00FF9FF828FFFFFB0079825A /* Month + extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Month + extension.swift"; sourceTree = "<group>"; };
 		6C316A1C28F6956D006A7473 /* Notifisor.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Notifisor.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6C316A1F28F6956D006A7473 /* NotifisorApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotifisorApp.swift; sourceTree = "<group>"; };
@@ -106,6 +110,8 @@
 		6C316A1328F6956D006A7473 = {
 			isa = PBXGroup;
 			children = (
+				00E08A982901134B0008D743 /* Day+CoreDataClass.swift */,
+				00E08A992901134B0008D743 /* Day+CoreDataProperties.swift */,
 				00DAAD3A290002C300BCE729 /* Month+CoreDataClass.swift */,
 				00DAAD3B290002C300BCE729 /* Month+CoreDataProperties.swift */,
 				6C316A1E28F6956D006A7473 /* Notifisor */,
@@ -322,6 +328,7 @@
 				6CE5774328F7E8F200A4CF7A /* NumbersOnly.swift in Sources */,
 				00DAAD3C290002C300BCE729 /* Month+CoreDataClass.swift in Sources */,
 				0032950928F83573002376DD /* FulfillmentView.swift in Sources */,
+				00E08A9B2901134B0008D743 /* Day+CoreDataProperties.swift in Sources */,
 				00A4F55628FE9581001F4508 /* DTO.xcdatamodeld in Sources */,
 				0032950528F7EC53002376DD /* RepeatSectionCell.swift in Sources */,
 				6CE5774928F8010C00A4CF7A /* Date + extension.swift in Sources */,
@@ -338,6 +345,7 @@
 				6CA163DF28F7A89F00E018F4 /* DailyNoticeCell.swift in Sources */,
 				6CE5774D28F8376200A4CF7A /* CalendarView.swift in Sources */,
 				6CA163E528F7A8E100E018F4 /* Notice.swift in Sources */,
+				00E08A9A2901134B0008D743 /* Day+CoreDataClass.swift in Sources */,
 				0032952A28F98D3A002376DD /* SectionHeaderText.swift in Sources */,
 				6CA163E128F7A8B200E018F4 /* DayCell.swift in Sources */,
 				00A4F55828FE9A41001F4508 /* PersistenceController.swift in Sources */,

--- a/Notifisor/Notifisor.xcodeproj/project.pbxproj
+++ b/Notifisor/Notifisor.xcodeproj/project.pbxproj
@@ -17,6 +17,9 @@
 		00A4F55828FE9A41001F4508 /* PersistenceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A4F55728FE9A41001F4508 /* PersistenceController.swift */; };
 		00D17CB728F7ABB3007DEDC8 /* DailyNoticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00D17CB628F7ABB3007DEDC8 /* DailyNoticeView.swift */; };
 		00D9DB4428FD2B060030A2C7 /* DayOfWeekView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00D9DB4328FD2B060030A2C7 /* DayOfWeekView.swift */; };
+		00DAAD3C290002C300BCE729 /* Month+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00DAAD3A290002C300BCE729 /* Month+CoreDataClass.swift */; };
+		00DAAD3D290002C300BCE729 /* Month+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00DAAD3B290002C300BCE729 /* Month+CoreDataProperties.swift */; };
+		00FF9FF928FFFFFB0079825A /* Month + extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00FF9FF828FFFFFB0079825A /* Month + extension.swift */; };
 		6C316A2028F6956D006A7473 /* NotifisorApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C316A1F28F6956D006A7473 /* NotifisorApp.swift */; };
 		6C316A2228F6956D006A7473 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C316A2128F6956D006A7473 /* ContentView.swift */; };
 		6C316A2428F6956F006A7473 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6C316A2328F6956F006A7473 /* Assets.xcassets */; };
@@ -48,6 +51,9 @@
 		00A4F55728FE9A41001F4508 /* PersistenceController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceController.swift; sourceTree = "<group>"; };
 		00D17CB628F7ABB3007DEDC8 /* DailyNoticeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyNoticeView.swift; sourceTree = "<group>"; };
 		00D9DB4328FD2B060030A2C7 /* DayOfWeekView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayOfWeekView.swift; sourceTree = "<group>"; };
+		00DAAD3A290002C300BCE729 /* Month+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "Month+CoreDataClass.swift"; path = "Notifisor/CoreData/Month+CoreDataClass.swift"; sourceTree = "<group>"; };
+		00DAAD3B290002C300BCE729 /* Month+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "Month+CoreDataProperties.swift"; path = "Notifisor/CoreData/Month+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		00FF9FF828FFFFFB0079825A /* Month + extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Month + extension.swift"; sourceTree = "<group>"; };
 		6C316A1C28F6956D006A7473 /* Notifisor.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Notifisor.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6C316A1F28F6956D006A7473 /* NotifisorApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotifisorApp.swift; sourceTree = "<group>"; };
 		6C316A2128F6956D006A7473 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -100,6 +106,8 @@
 		6C316A1328F6956D006A7473 = {
 			isa = PBXGroup;
 			children = (
+				00DAAD3A290002C300BCE729 /* Month+CoreDataClass.swift */,
+				00DAAD3B290002C300BCE729 /* Month+CoreDataProperties.swift */,
 				6C316A1E28F6956D006A7473 /* Notifisor */,
 				6C316A1D28F6956D006A7473 /* Products */,
 			);
@@ -230,6 +238,7 @@
 			children = (
 				6CE5774828F8010C00A4CF7A /* Date + extension.swift */,
 				6CE5775028F94E6300A4CF7A /* Calendar + extension.swift */,
+				00FF9FF828FFFFFB0079825A /* Month + extension.swift */,
 				6CE5775228F94EC900A4CF7A /* DateFormatter + extension.swift */,
 			);
 			path = Extension;
@@ -311,6 +320,7 @@
 				6C316A2228F6956D006A7473 /* ContentView.swift in Sources */,
 				6CA163E728F7A8F400E018F4 /* TodayViewModel.swift in Sources */,
 				6CE5774328F7E8F200A4CF7A /* NumbersOnly.swift in Sources */,
+				00DAAD3C290002C300BCE729 /* Month+CoreDataClass.swift in Sources */,
 				0032950928F83573002376DD /* FulfillmentView.swift in Sources */,
 				00A4F55628FE9581001F4508 /* DTO.xcdatamodeld in Sources */,
 				0032950528F7EC53002376DD /* RepeatSectionCell.swift in Sources */,
@@ -319,9 +329,11 @@
 				6CE5774B28F8020600A4CF7A /* HistoryNoticeCell.swift in Sources */,
 				6CE5774528F7EB5F00A4CF7A /* Repeat.swift in Sources */,
 				6CA163EB28F7B63100E018F4 /* NoticeEditView.swift in Sources */,
+				00DAAD3D290002C300BCE729 /* Month+CoreDataProperties.swift in Sources */,
 				0032950728F7EE24002376DD /* RepeatSectionView.swift in Sources */,
 				6CA163E328F7A8CD00E018F4 /* HistoryNoticeView.swift in Sources */,
 				6CE5774128F7E8A400A4CF7A /* Unit.swift in Sources */,
+				00FF9FF928FFFFFB0079825A /* Month + extension.swift in Sources */,
 				0032952528F9024C002376DD /* MenuView.swift in Sources */,
 				6CA163DF28F7A89F00E018F4 /* DailyNoticeCell.swift in Sources */,
 				6CE5774D28F8376200A4CF7A /* CalendarView.swift in Sources */,

--- a/Notifisor/Notifisor/CoreData/DTO.xcdatamodeld/DTO.xcdatamodel/contents
+++ b/Notifisor/Notifisor/CoreData/DTO.xcdatamodeld/DTO.xcdatamodel/contents
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21277" systemVersion="21G83" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
-    <entity name="Day" representedClassName="Day" syncable="YES" codeGenerationType="class">
+    <entity name="Day" representedClassName="Day" syncable="YES">
         <attribute name="achievementRate" optional="YES" attributeType="Float" defaultValueString="0.0" usesScalarValueType="YES"/>
-        <attribute name="date" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="date" attributeType="Date" usesScalarValueType="NO"/>
         <relationship name="month" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Month" inverseName="days" inverseEntity="Month"/>
         <relationship name="notices" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Notice" inverseName="day" inverseEntity="Notice"/>
     </entity>

--- a/Notifisor/Notifisor/CoreData/DTO.xcdatamodeld/DTO.xcdatamodel/contents
+++ b/Notifisor/Notifisor/CoreData/DTO.xcdatamodeld/DTO.xcdatamodel/contents
@@ -6,7 +6,7 @@
         <relationship name="month" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Month" inverseName="days" inverseEntity="Month"/>
         <relationship name="notices" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Notice" inverseName="day" inverseEntity="Notice"/>
     </entity>
-    <entity name="Month" representedClassName="Month" syncable="YES" codeGenerationType="class">
+    <entity name="Month" representedClassName="Month" syncable="YES">
         <attribute name="date" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <relationship name="days" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Day" inverseName="month" inverseEntity="Day"/>
     </entity>

--- a/Notifisor/Notifisor/CoreData/DTO.xcdatamodeld/DTO.xcdatamodel/contents
+++ b/Notifisor/Notifisor/CoreData/DTO.xcdatamodeld/DTO.xcdatamodel/contents
@@ -8,7 +8,7 @@
     </entity>
     <entity name="Month" representedClassName="Month" syncable="YES" codeGenerationType="class">
         <attribute name="date" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
-        <relationship name="days" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Day" inverseName="month" inverseEntity="Day"/>
+        <relationship name="days" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Day" inverseName="month" inverseEntity="Day"/>
     </entity>
     <entity name="Notice" representedClassName="Notice" syncable="YES" codeGenerationType="class">
         <attribute name="amount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" customClassName="Int"/>

--- a/Notifisor/Notifisor/CoreData/DTO.xcdatamodeld/DTO.xcdatamodel/contents
+++ b/Notifisor/Notifisor/CoreData/DTO.xcdatamodeld/DTO.xcdatamodel/contents
@@ -1,5 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21279" systemVersion="21G115" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21277" systemVersion="21G83" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="Day" representedClassName="Day" syncable="YES" codeGenerationType="class">
+        <attribute name="achievementRate" optional="YES" attributeType="Float" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="date" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <relationship name="month" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Month" inverseName="days" inverseEntity="Month"/>
+        <relationship name="notices" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Notice" inverseName="day" inverseEntity="Notice"/>
+    </entity>
+    <entity name="Month" representedClassName="Month" syncable="YES" codeGenerationType="class">
+        <attribute name="date" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <relationship name="days" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Day" inverseName="month" inverseEntity="Day"/>
+    </entity>
     <entity name="Notice" representedClassName="Notice" syncable="YES" codeGenerationType="class">
         <attribute name="amount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" customClassName="Int"/>
         <attribute name="isDone" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
@@ -7,5 +17,6 @@
         <attribute name="repeats" optional="YES" attributeType="Transformable" customClassName="[String]"/>
         <attribute name="title" optional="YES" attributeType="String"/>
         <attribute name="unit" optional="YES" attributeType="String"/>
+        <relationship name="day" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Day" inverseName="notices" inverseEntity="Day"/>
     </entity>
 </model>

--- a/Notifisor/Notifisor/CoreData/Day+CoreDataClass.swift
+++ b/Notifisor/Notifisor/CoreData/Day+CoreDataClass.swift
@@ -1,0 +1,15 @@
+//
+//  Day+CoreDataClass.swift
+//  Notifisor
+//
+//  Created by YEONGJIN JANG on 2022/10/20.
+//
+//
+
+import Foundation
+import CoreData
+
+@objc(Day)
+public class Day: NSManagedObject {
+
+}

--- a/Notifisor/Notifisor/CoreData/Day+CoreDataProperties.swift
+++ b/Notifisor/Notifisor/CoreData/Day+CoreDataProperties.swift
@@ -43,3 +43,14 @@ extension Day {
 extension Day : Identifiable {
 
 }
+
+extension Day: Comparable {
+    public static func <(lhs: Day, rhs: Day) -> Bool {
+        guard let lhsDate = lhs.date,
+              let rhsDate = rhs.date
+        else {
+            fatalError("dates are invalid")
+        }
+        return lhsDate < rhsDate
+    }
+}

--- a/Notifisor/Notifisor/CoreData/Day+CoreDataProperties.swift
+++ b/Notifisor/Notifisor/CoreData/Day+CoreDataProperties.swift
@@ -1,0 +1,45 @@
+//
+//  Day+CoreDataProperties.swift
+//  Notifisor
+//
+//  Created by YEONGJIN JANG on 2022/10/20.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension Day {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<Day> {
+        return NSFetchRequest<Day>(entityName: "Day")
+    }
+
+    @NSManaged public var achievementRate: Float
+    @NSManaged public var date: Date?
+    @NSManaged public var month: Month?
+    @NSManaged public var notices: NSSet?
+
+}
+
+// MARK: Generated accessors for notices
+extension Day {
+
+    @objc(addNoticesObject:)
+    @NSManaged public func addToNotices(_ value: Notice)
+
+    @objc(removeNoticesObject:)
+    @NSManaged public func removeFromNotices(_ value: Notice)
+
+    @objc(addNotices:)
+    @NSManaged public func addToNotices(_ values: NSSet)
+
+    @objc(removeNotices:)
+    @NSManaged public func removeFromNotices(_ values: NSSet)
+
+}
+
+extension Day : Identifiable {
+
+}

--- a/Notifisor/Notifisor/CoreData/Day+CoreDataProperties.swift
+++ b/Notifisor/Notifisor/CoreData/Day+CoreDataProperties.swift
@@ -43,14 +43,3 @@ extension Day {
 extension Day : Identifiable {
 
 }
-
-extension Day: Comparable {
-    public static func <(lhs: Day, rhs: Day) -> Bool {
-        guard let lhsDate = lhs.date,
-              let rhsDate = rhs.date
-        else {
-            fatalError("dates are invalid")
-        }
-        return lhsDate < rhsDate
-    }
-}

--- a/Notifisor/Notifisor/CoreData/Month+CoreDataClass.swift
+++ b/Notifisor/Notifisor/CoreData/Month+CoreDataClass.swift
@@ -1,0 +1,15 @@
+//
+//  Month+CoreDataClass.swift
+//  Notifisor
+//
+//  Created by YEONGJIN JANG on 2022/10/19.
+//
+//
+
+import Foundation
+import CoreData
+
+@objc(Month)
+public class Month: NSManagedObject {
+
+}

--- a/Notifisor/Notifisor/CoreData/Month+CoreDataProperties.swift
+++ b/Notifisor/Notifisor/CoreData/Month+CoreDataProperties.swift
@@ -1,0 +1,43 @@
+//
+//  Month+CoreDataProperties.swift
+//  Notifisor
+//
+//  Created by YEONGJIN JANG on 2022/10/19.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension Month {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<Month> {
+        return NSFetchRequest<Month>(entityName: "Month")
+    }
+
+    @NSManaged public var date: Date?
+    @NSManaged public var days: NSSet?
+
+}
+
+// MARK: Generated accessors for days
+extension Month {
+
+    @objc(addDaysObject:)
+    @NSManaged public func addToDays(_ value: Day)
+
+    @objc(removeDaysObject:)
+    @NSManaged public func removeFromDays(_ value: Day)
+
+    @objc(addDays:)
+    @NSManaged public func addToDays(_ values: NSSet)
+
+    @objc(removeDays:)
+    @NSManaged public func removeFromDays(_ values: NSSet)
+
+}
+
+extension Month : Identifiable {
+
+}

--- a/Notifisor/Notifisor/Support/Extension/Calendar + extension.swift
+++ b/Notifisor/Notifisor/Support/Extension/Calendar + extension.swift
@@ -30,4 +30,25 @@ extension Calendar {
         let components = Calendar.current.dateComponents([.year, .month], from: date)
         return Calendar.current.date(from: components) ?? Date.now
     }
+
+    static func generateMonthDate(_ year: Int, _ month: Int) -> Date {
+        var components = DateComponents()
+        components.year = year
+        components.month = month
+        return Calendar.current.date(from: components) ?? Date()
+    }
+
+    static func days(for month: Date) -> [Date] {
+        let calendar = Self.current
+        guard
+            let monthInterval = calendar.dateInterval(of: .month, for: month),
+            let monthFirstWeek = calendar.dateInterval(of: .weekOfMonth, for: monthInterval.start),
+            let monthLastWeek = calendar.dateInterval(of: .weekOfMonth, for: monthInterval.end)
+        else { return [] }
+
+        return calendar.generateDates(
+            inside: DateInterval(start: monthFirstWeek.start, end: monthLastWeek.end),
+            matching: DateComponents(hour: 0, minute: 0, second: 0)
+        )
+    }
 }

--- a/Notifisor/Notifisor/Support/Extension/Calendar + extension.swift
+++ b/Notifisor/Notifisor/Support/Extension/Calendar + extension.swift
@@ -25,4 +25,9 @@ extension Calendar {
         }
         return dates
     }
+
+    static func generateMonthDate(_ date: Date) -> Date {
+        let components = Calendar.current.dateComponents([.year, .month], from: date)
+        return Calendar.current.date(from: components) ?? Date.now
+    }
 }

--- a/Notifisor/Notifisor/Support/Extension/Calendar + extension.swift
+++ b/Notifisor/Notifisor/Support/Extension/Calendar + extension.swift
@@ -31,14 +31,14 @@ extension Calendar {
         return Calendar.current.date(from: components) ?? Date.now
     }
 
-    static func generateMonthDate(_ year: Int, _ month: Int) -> Date {
+    func generateMonthDate(_ year: Int, _ month: Int) -> Date {
         var components = DateComponents()
         components.year = year
         components.month = month
         return Calendar.current.date(from: components) ?? Date()
     }
 
-    static func days(for month: Date) -> [Date] {
+    func days(for month: Date) -> [Date] {
         let calendar = Self.current
         guard
             let monthInterval = calendar.dateInterval(of: .month, for: month),

--- a/Notifisor/Notifisor/Support/Extension/Day + extension.swift
+++ b/Notifisor/Notifisor/Support/Extension/Day + extension.swift
@@ -1,0 +1,20 @@
+//
+//  Day + extension.swift
+//  Notifisor
+//
+//  Created by YEONGJIN JANG on 2022/10/20.
+//
+
+import CoreData
+import Foundation
+
+extension Day: Comparable {
+    public static func <(lhs: Day, rhs: Day) -> Bool {
+        guard let lhsDate = lhs.date,
+              let rhsDate = rhs.date
+        else {
+            fatalError("dates are invalid")
+        }
+        return lhsDate < rhsDate
+    }
+}

--- a/Notifisor/Notifisor/Support/Extension/Month + extension.swift
+++ b/Notifisor/Notifisor/Support/Extension/Month + extension.swift
@@ -4,5 +4,33 @@
 //
 //  Created by YEONGJIN JANG on 2022/10/19.
 //
-
+import CoreData
 import Foundation
+
+extension Month {
+    //MARK: - making entity, saving context
+    static func add12MonthEntity() {
+        let context = PersistenceController.shared.container.viewContext
+
+        for monthNumber in 1...12 {
+            let month = Month(context: context)
+            let representDate = Calendar.generateMonthDate(2022, monthNumber)
+            let datesOfMonth = Calendar.days(for: representDate)
+
+            let days: [Day] = datesOfMonth.compactMap { dateElement in
+                let day = Day(context: context)
+                day.date = dateElement
+                return day
+            }
+
+            month.date = representDate
+            month.days = NSSet(array: days)
+        }
+
+        do {
+            try context.save()
+        } catch {
+            print("error: fail at saving 12 month")
+        }
+    }
+}

--- a/Notifisor/Notifisor/Support/Extension/Month + extension.swift
+++ b/Notifisor/Notifisor/Support/Extension/Month + extension.swift
@@ -1,0 +1,8 @@
+//
+//  Month + extension.swift
+//  Notifisor
+//
+//  Created by YEONGJIN JANG on 2022/10/19.
+//
+
+import Foundation

--- a/Notifisor/Notifisor/Support/Extension/Month + extension.swift
+++ b/Notifisor/Notifisor/Support/Extension/Month + extension.swift
@@ -11,11 +11,12 @@ extension Month {
     //MARK: - making entity, saving context
     static func add12MonthEntity() {
         let context = PersistenceController.shared.container.viewContext
+        let calendar = Calendar.current
 
         for monthNumber in 1...12 {
             let month = Month(context: context)
-            let representDate = Calendar.generateMonthDate(2022, monthNumber)
-            let datesOfMonth = Calendar.days(for: representDate)
+            let representDate = calendar.generateMonthDate(2022, monthNumber)
+            let datesOfMonth = calendar.days(for: representDate)
 
             let days: [Day] = datesOfMonth.compactMap { dateElement in
                 let day = Day(context: context)

--- a/Notifisor/Notifisor/Support/Extension/Month + extension.swift
+++ b/Notifisor/Notifisor/Support/Extension/Month + extension.swift
@@ -29,6 +29,7 @@ extension Month {
 
         do {
             try context.save()
+            print("success saving 12 month")
         } catch {
             print("error: fail at saving 12 month")
         }

--- a/Notifisor/Notifisor/View/History/CalendarView.swift
+++ b/Notifisor/Notifisor/View/History/CalendarView.swift
@@ -39,6 +39,8 @@ struct CalendarView: View {
                         } label: {
                             Image(systemName: "chevron.left")
                         }
+                        .disabled(isStartMonth())
+
 
                         Text(DateFormatter.monthAndYear.string(from: month.first?.date ?? Date()))
                             .font(.title)
@@ -48,6 +50,7 @@ struct CalendarView: View {
                         } label: {
                             Image(systemName: "chevron.right")
                         }
+                        .disabled(isCurrentMonth())
 
                     }
                 }
@@ -67,6 +70,23 @@ struct CalendarView: View {
             .date(byAdding: .month, value: move, to: currentDate) ?? Date()
         month.nsPredicate = NSPredicate(format: "date == %@", argumentArray: [movedDate])
     }
+
+    private func isCurrentMonth() -> Bool {
+        let presentDate = month.first?.date ?? Date()
+        let componentsOfPresent = calendar.dateComponents([.year, .month], from: presentDate)
+        let nowComponents = calendar.dateComponents([.year, .month], from: Date.now)
+        return componentsOfPresent == nowComponents
+    }
+
+    //MARK: - 사용자가 이 앱을 다운로드한 날이 2022년 8월이라고 가정
+    private func isStartMonth() -> Bool {
+        let startDate =  calendar.generateMonthDate(2022, 8)
+        let startComponents = calendar.dateComponents([.year, .month], from: startDate)
+        let presentDate = month.first?.date ?? Date()
+        let presentComponents = calendar.dateComponents([.year, .month], from: presentDate)
+        return startComponents == presentComponents
+    }
+
 }
 
 struct CalendarView_Previews: PreviewProvider {

--- a/Notifisor/Notifisor/View/History/CalendarView.swift
+++ b/Notifisor/Notifisor/View/History/CalendarView.swift
@@ -8,23 +8,12 @@ import SwiftUI
 
 struct CalendarView: View {
     @Environment(\.calendar) var calendar
-    @Environment(\.managedObjectContext) var context
 
     @FetchRequest (
         entity: Month.entity(),
         sortDescriptors: [],
         predicate: NSPredicate(format: "date == %@", argumentArray: [Calendar.generateMonthDate(Date.now)])
     ) var month: FetchedResults<Month>
-
-//    @State var month: Date = Date.now
-
-//    private var beforeMonth: Date {
-//        return Calendar.current.date(byAdding: .month, value: -1, to: month) ?? Date()
-//    }
-//
-//    private var nextMonth: Date {
-//        return Calendar.current.date(byAdding: .month, value: 1, to: month) ?? Date()
-//    }
 
     var body: some View {
         VStack {
@@ -34,20 +23,18 @@ struct CalendarView: View {
                     if let days = month.first?.days?.allObjects as? [Day],
                        let representDate = month.first?.date
                     {
-                        ForEach(days, id: \.self) { day in
-//                            let cell = DayCell(day: date.get(.day))
+                        ForEach(days.sorted(), id: \.self) { day in
                             let cell = DayCell(day: day.date?.get(.day) ?? 0)
                             if calendar.isDate(day.date ?? Date(), equalTo: representDate, toGranularity: .month) {
                                 cell
                             } else {
-//                                cell.hidden()
+                                cell.hidden()
                             }
                         }
                     }
                 } header: {
                     HStack {
                         Button {
-//                            month = beforeMonth
                             fetchMonth(isNextTo: false)
                         } label: {
                             Image(systemName: "chevron.left")
@@ -57,7 +44,6 @@ struct CalendarView: View {
                             .font(.title)
 
                         Button {
-//                            month = nextMonth
                             fetchMonth(isNextTo: true)
                         } label: {
                             Image(systemName: "chevron.right")
@@ -72,19 +58,6 @@ struct CalendarView: View {
             .shadow(radius: 1, x: 5, y: 5)
         }
 
-    }
-
-    private func days(for month: Date) -> [Date] {
-        guard
-            let monthInterval = calendar.dateInterval(of: .month, for: month),
-            let monthFirstWeek = calendar.dateInterval(of: .weekOfMonth, for: monthInterval.start),
-            let monthLastWeek = calendar.dateInterval(of: .weekOfMonth, for: monthInterval.end)
-        else { return [] }
-
-        return calendar.generateDates(
-            inside: DateInterval(start: monthFirstWeek.start, end: monthLastWeek.end),
-            matching: DateComponents(hour: 0, minute: 0, second: 0)
-        )
     }
 
     private func fetchMonth(isNextTo: Bool) {

--- a/Notifisor/Notifisor/View/History/CalendarView.swift
+++ b/Notifisor/Notifisor/View/History/CalendarView.swift
@@ -20,7 +20,7 @@ struct CalendarView: View {
     }
 
     var body: some View {
-        NavigationView {
+        VStack {
             LazyVGrid(columns: Array(repeating: GridItem(), count: 7), alignment: .center, spacing: 16) {
                 Section {
                     DayOfWeekView()
@@ -51,7 +51,6 @@ struct CalendarView: View {
 
                     }
                 }
-
             }
             .padding()
             .background(.ultraThickMaterial)

--- a/Notifisor/Notifisor/View/Today/DailyNoticeView.swift
+++ b/Notifisor/Notifisor/View/Today/DailyNoticeView.swift
@@ -45,6 +45,13 @@ struct DailyNoticeView: View {
                         .sheet(isPresented: $showSheet) {
                             NoticeEditView()
                         }
+
+                        Button {
+                            Month.add12MonthEntity()
+                        } label: {
+                            ColoredImage(source: "12.square")
+                            Text("add monthes")
+                        }
                     }
 
                     ToolbarItemGroup(placement: .navigationBarLeading) {


### PR DESCRIPTION
## 작업 내용
- [x] Day, Month 등 코어 데이터 클래스의 extension 을 직접 구현 
- [x] CalendarView 에 있던 [Date] 생성 메서드를 Calendar 의 extension으로 이동
- [x] `@State var month` 에서 `@FetchRequest var month` 를 기반으로 CalendarView에서 달력 그림
- [x] 시작월, 현재월에 따라 "<,>" 버튼 각각 비활성화