### PR TITLE
FlexibleView data 로직

### DIFF
--- a/Notifisor/Notifisor/Model/Notice/CurrentNotice.swift
+++ b/Notifisor/Notifisor/Model/Notice/CurrentNotice.swift
@@ -16,3 +16,9 @@ final class CurrentNotice: NoticeType {
         return rootId
     }
 }
+
+extension CurrentNotice: Comparable {
+    static func < (lhs: CurrentNotice, rhs: CurrentNotice) -> Bool {
+        return lhs.title < rhs.title
+    }
+}

--- a/Notifisor/Notifisor/Model/NoticeRepository.swift
+++ b/Notifisor/Notifisor/Model/NoticeRepository.swift
@@ -27,8 +27,6 @@ final class NoticeRepository: ObservableObject {
 
         if weekday == nil { createWeekDay() }
         if day == nil { createDay() }
-
-        searchDays(in: Date.kst)
     }
 
     private func createWeekDay() {

--- a/Notifisor/Notifisor/Model/NoticeRepository.swift
+++ b/Notifisor/Notifisor/Model/NoticeRepository.swift
@@ -22,11 +22,13 @@ final class NoticeRepository: ObservableObject {
             fatalError("DB Load Failure")
         }
 
-        self.weekday = get(Weekday.self, Date.now.get(.weekday))
-        self.day = get(Day.self, Date.now.id)
+        self.weekday = get(Weekday.self, Date.kst.get(.weekday))
+        self.day = get(Day.self, Date.kst.id)
 
         if weekday == nil { createWeekDay() }
         if day == nil { createDay() }
+
+        searchDays(in: Date.kst)
     }
 
     private func createWeekDay() {
@@ -39,14 +41,14 @@ final class NoticeRepository: ObservableObject {
 
     private func createDay() {
         write {
-            let today = Date.now
+            let today = Date.kst
             let totalNotices = List<CurrentNotice>()
             weekday?.notices.forEach { totalNotices.append($0.toCurrent()) }
 
             realm.create(Day.self,
                          value: ["_id": today.id, "date": today, "notices": totalNotices],
                          update: .modified)
-            self.day = get(Day.self, Date.now.id)
+            self.day = get(Day.self, Date.kst.id)
         }
     }
 
@@ -63,7 +65,7 @@ final class NoticeRepository: ObservableObject {
         write {
             notice.repeats.forEach { get(Weekday.self, $0)?.notices.append(notice) }
 
-            if notice.repeats.contains(Date.now.get(.weekday)) || notice.repeats.isEmpty {
+            if notice.repeats.contains(Date.kst.get(.weekday)) || notice.repeats.isEmpty {
                 day?.notices.append(notice.toCurrent())
             }
         }

--- a/Notifisor/Notifisor/Support/Extension/Calendar + extension.swift
+++ b/Notifisor/Notifisor/Support/Extension/Calendar + extension.swift
@@ -28,7 +28,7 @@ extension Calendar {
 
     static func generateMonthDate(_ date: Date) -> Date {
         let components = Calendar.current.dateComponents([.year, .month], from: date)
-        return Calendar.current.date(from: components) ?? Date.now
+        return Calendar.current.date(from: components) ?? Date.kst
     }
 
     func generateMonthDate(_ year: Int, _ month: Int) -> Date {

--- a/Notifisor/Notifisor/Support/Extension/Date + extension.swift
+++ b/Notifisor/Notifisor/Support/Extension/Date + extension.swift
@@ -8,6 +8,14 @@
 import Foundation
 
 extension Date {
+    var kst: Date {
+        return self.addingTimeInterval(32400)
+    }
+
+    static var kst: Date {
+        return Date.now.addingTimeInterval(32400)
+    }
+
     func get(_ components: Calendar.Component..., calendar: Calendar = Calendar.current) -> DateComponents {
         return calendar.dateComponents(Set(components), from: self)
     }
@@ -18,6 +26,14 @@ extension Date {
 
     func split() -> [Int] {
         return [self.get(.year), self.get(.month), self.get(.day)]
+    }
+
+    func startOfMonth() -> Date {
+        return Calendar.current.date(from: Calendar.current.dateComponents([.year, .month], from: Calendar.current.startOfDay(for: self))) ?? Date.kst
+    }
+
+    func endOfMonth() -> Date {
+        return Calendar.current.date(byAdding: DateComponents(month: 1, day: -1), to: self.startOfMonth()) ?? Date.kst
     }
 
     var id: String {

--- a/Notifisor/Notifisor/View/History/CalendarView.swift
+++ b/Notifisor/Notifisor/View/History/CalendarView.swift
@@ -8,9 +8,9 @@ import SwiftUI
 
 struct CalendarView: View {
     @Environment(\.calendar) var calendar: Calendar
-    @State var date: Date = .now
-    @State var year: Int = Date.now.get(.year)
-    @State var month: Int = Date.now.get(.month)
+    @State var date: Date = .kst
+    @State var year: Int = Date.kst.get(.year)
+    @State var month: Int = Date.kst.get(.month)
     @State var isShowing: Bool = false
 
     var body: some View {

--- a/Notifisor/Notifisor/View/History/CalendarView.swift
+++ b/Notifisor/Notifisor/View/History/CalendarView.swift
@@ -39,10 +39,23 @@ struct CalendarView: View {
     }
 
     private func getMost(notices: [CurrentNotice]) -> [CurrentNotice: Double] {
-        var counter: [CurrentNotice: Double] = [:]
-        notices.forEach { counter[$0, default: 0] += $0.amount ?? 0}
+        var idMap: [ObjectId: CurrentNotice] = [:]
+        var amount: [ObjectId: Double] = [:]
+        var counter: [ObjectId: Int] = [:]
+
+        notices.forEach {
+            idMap[$0.targetId] = $0
+            amount[$0.targetId, default: 0] += $0.amount ?? 0
+            counter[$0.targetId, default: 0] += 1
+        }
         let max = counter.values.max()
 
-        return counter.filter { $0.value == max }
+        var result: [CurrentNotice: Double] = [:]
+
+        amount.filter { key, _ in counter[key] == max }.forEach { id, value in
+            result[idMap[id, default: .init()]] = value
+        }
+        
+        return result
     }
 }

--- a/Notifisor/Notifisor/View/History/CalendarView.swift
+++ b/Notifisor/Notifisor/View/History/CalendarView.swift
@@ -30,9 +30,7 @@ struct CalendarView: View {
                 if let filtered = days.filter("date BETWEEN {%@, %@}", date.startOfMonth(), date.endOfMonth()),
                    let notices = filtered.reduce(into: [CurrentNotice]()) { $0 += $1.notices.filter { $0.isDone } },
                    let targets = getMost(notices: notices) {
-                    ForEach(targets.sorted(by: <), id: \.key) { notice, count in
-                        FlexibleView(data: notice, amount: count)
-                    }
+                       FlexibleView(data: targets)
                 }
             }
             .padding(.horizontal)
@@ -40,7 +38,7 @@ struct CalendarView: View {
         .background(Constant.background)
     }
 
-    func getMost(notices: [CurrentNotice]) -> [CurrentNotice: Double] {
+    private func getMost(notices: [CurrentNotice]) -> [CurrentNotice: Double] {
         var counter: [CurrentNotice: Double] = [:]
         notices.forEach { counter[$0, default: 0] += $0.amount ?? 0}
         let max = counter.values.max()

--- a/Notifisor/Notifisor/View/History/CustomPicker.swift
+++ b/Notifisor/Notifisor/View/History/CustomPicker.swift
@@ -10,7 +10,8 @@ import SwiftUI
 struct CustomPicker: View {
     let months: [Int] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
     let startYear: Int = 2000
-    let endYear: Int = Date.now.get(.year)
+    let endYear: Int = Date.kst.get(.year)
+
     @Binding var date: Date
     @Binding var year: Int
     @Binding var month: Int

--- a/Notifisor/Notifisor/View/History/FlexibleView.swift
+++ b/Notifisor/Notifisor/View/History/FlexibleView.swift
@@ -10,12 +10,9 @@ import SwiftUI
 struct FlexibleView: View {
     @State private var showDetail = false
     let data: CurrentNotice
+    let amount: Double
     private var textMessage: String {
-        "\(data.title)를 총 \(simpleAmount)\(data.unit.text) 했습니다."
-    }
-    
-    private var simpleAmount: Double {
-        (data.amount ?? 0) * Double(data.repeats.count)
+        "\(data.title)를 총 \(amount)\(data.unit.text) 했습니다."
     }
     
     var body: some View {
@@ -51,17 +48,5 @@ struct FlexibleView: View {
                 self.showDetail.toggle()
             }
         }
-    }
-}
-
-struct FlexibleView_Previews: PreviewProvider {
-    static var previews: some View {
-        let currentNotice = CurrentNotice()
-        currentNotice.title = "달리기"
-        currentNotice.repeats.append(objectsIn: [1,3,5])
-        currentNotice.unit = .km
-        currentNotice.amount = 3
-        
-        return FlexibleView(data: currentNotice)
     }
 }

--- a/Notifisor/Notifisor/View/History/FlexibleView.swift
+++ b/Notifisor/Notifisor/View/History/FlexibleView.swift
@@ -9,12 +9,8 @@ import SwiftUI
 
 struct FlexibleView: View {
     @State private var showDetail = false
-    let data: CurrentNotice
-    let amount: Double
-    private var textMessage: String {
-        "\(data.title)를 총 \(amount)\(data.unit.text) 했습니다."
-    }
-    
+    let data: [CurrentNotice: Double]
+
     var body: some View {
         VStack(alignment: .leading) {
             HStack {
@@ -38,8 +34,10 @@ struct FlexibleView: View {
             }
             
             if showDetail {
-                Text(textMessage)
-                    .padding(.top, 30)
+                ForEach(data.sorted(by: <), id: \.key) {
+                    Text("\($0.title)를 총 \(String(format: "%.1f", $1))\($0.unit.text) 했습니다.")
+                        .padding(.top, 30)
+                }
             }
         }
         .shadowCellStyle()


### PR DESCRIPTION
- Date.kst 생성
  - 기존의 경우 12월 1일 00:00 의 경우 UTC 11월 30일 15:00 으로 나오는 현상을 해결하기 위해 만들었습니다.
  - Date.now로 생성시 UTC 값이 생성되어 9시간을 더해주는 kst 값으로 모두 변경하였습니다.
  - DateFormatter에서 timezone을 바꿀수 있지만, NSPredicate 구문중 BETWEEN의 경우 string에서 작동하지 않아 Date 에 시간을 더해주는 방식으로 만들어 사용했습니다.
- CurrentNotice: Comparable 추가
  -  ForEach 구문에서 dictionary 타입의 key, value를 사용하기 위해 sorted(by:) 메소드를 사용해야 했습니다.
    - ForEach 문에서 사용하는 컬렉션의 경우 [RandomAccessCollection](https://developer.apple.com/documentation/swift/randomaccesscollection) 을 준수해야 합니다. (ex. array 처럼 인덱스로 O(1)로 접근 가능한 형태)

- amount 값 표시 방법 변경
  - 기존 알림의 반복횟수를 amount로 표시하는 로직을 해당 월 해당 알림을 몇번 완료했는지를 표시하기위해 변경했습니다.

- 가장 많이 달성한 일정 present
  - 코드에서 설명 하겠습니다.
